### PR TITLE
Reload optimizer params when loading bf16 ckpt

### DIFF
--- a/megatron/checkpointing.py
+++ b/megatron/checkpointing.py
@@ -582,7 +582,7 @@ def load_checkpoint(model, optimizer, opt_param_scheduler, load_arg='load', stri
                          'exiting ...'.format(checkpoint_name))
             sys.exit()
     else:
-        if args.fp16 and optimizer is not None:
+        if (args.fp16 or args.bf16) and optimizer is not None:
             optimizer.reload_model_params()
 
     # rng states.

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -395,7 +395,7 @@ def setup_model_and_optimizer(model_provider_func,
         and hasattr(unwrapped_model[0], 'init_state_dict_from_bert'):
         print_rank_0("Initializing ICT from pretrained BERT model")
         unwrapped_model[0].init_state_dict_from_bert()
-        if args.fp16:
+        if args.fp16 or args.bf16:
             optimizer.reload_model_params()
 
     return model, optimizer, opt_param_scheduler


### PR DESCRIPTION
This PR is to fix this [issue](https://github.com/stanford-futuredata/megablocks/issues/80), when using bf16 and attempting to load pretrained model weights to continue training, the weights in the optimizer will not be reset to the pretrained model weights. 